### PR TITLE
Drchops histogram updates

### DIFF
--- a/danse/drchops/conda_build_config.yaml
+++ b/danse/drchops/conda_build_config.yaml
@@ -4,7 +4,7 @@ python:
 numpy:
   - 1.20.0
 histogram:
-  - 0.3.9
+  - 0.4
 
 pin_run_as_build:
   numpy:

--- a/danse/drchops/meta.yaml
+++ b/danse/drchops/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - danse.ins
     - journal
     - histogram
-    - pyre
+    - pyre =0.8.3
 
 build:
   script_env:


### PR DESCRIPTION
updates to the recipes files to be able to point to the new histogram at the neutrons channel (https://anaconda.org/neutrons/histogram/l)
drchops version has not been updated

drchops code has not changed. thus the version number is the same (?)


to test
- create and activate a conda environment e.g.:
    name: conda-recipe
    channels:
      - neutrons/label/rc
      - neutrons/label/main
      - mcvine
      - conda-forge
    dependencies:
      - python=3.9
      - anaconda-client
      - boa
      - libmamba
      - libarchive
      - conda-build
      - conda-verify
      - gxx_linux-64
      - python-build
      - numpy
      - danse.ins
      - journal
      - histogram=0.4.2
      - pyre = 0.8.3
- cd danse/drchops
- conda build --channel neutrons/label/rc .
- the conda package(s) for drchops should be created . install with conda install <drcops.tar.bz2>

Related to [9463- Conda Package updates for neutrons:histogram](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/9463)