### PR TITLE
Production release 1.4.6

### DIFF
--- a/danse/bpext/meta.yaml
+++ b/danse/bpext/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: danse.ins.bpext
-  version: "0.1.5rc1"
+  version: "0.1.5"
 
 source:
   # Due to lack of access rights to the bpext repo and no change in the source code, we point directly to a specific commit (head of master - v0.1.4)

--- a/danse/numpyext/meta.yaml
+++ b/danse/numpyext/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: danse.ins.numpyext
-  version: "0.1.4rc1"
+  version: "0.1.4"
 
 source:
   # Due to lack of access rights to the numpyext repo and no change in the source code, we point directly to a specific commit (head of master - v0.1.3)

--- a/mcvine-core/meta.yaml
+++ b/mcvine-core/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: mcvine-core
-  version: "1.5.1rc2"
+  version: "1.5.1"
 
 source:
-  git_rev: v1.5.1rc2
+  git_rev: v1.5.1
   git_url: https://github.com/mcvine/mcvine.git
 
 requirements:

--- a/mcvine/meta.yaml
+++ b/mcvine/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: mcvine
-  version: "1.4.6rc1"
+  version: "1.4.6"
 
 requirements:
   run:
-    - mcvine-core               >=1.5.1rc1
+    - mcvine-core               >=1.5.1
     - mcvine.instruments
     - mcvine.workflow
     - mcvine.phonon


### PR DESCRIPTION
It contains production version updates for:
 - danse.ins.bpext v0.1.5
 - danse.ins.numpyext v0.1.4
 - mcvine-core v1.5.1
 - mcvine v1.4.6