### PR TITLE
CI finalization

### DIFF
--- a/.github/workflows/DanseDeploy.yml
+++ b/.github/workflows/DanseDeploy.yml
@@ -115,7 +115,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
 
   danse-ins-pkg:
     needs: check-permission
@@ -148,7 +148,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
 
   danse-dsm-pkg:
     needs: check-permission
@@ -182,7 +182,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
 
   danse-journal-pkg:
     needs: check-permission
@@ -215,7 +215,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
 
   danse-numpyext-pkg:
     needs: check-permission
@@ -248,7 +248,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
 
   danse-pyre-pkg:
     needs: check-permission
@@ -281,4 +281,4 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg

--- a/.github/workflows/McvineDeploy.yml
+++ b/.github/workflows/McvineDeploy.yml
@@ -125,7 +125,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
 
   mcvine-core-pkg:
     needs: check-permission
@@ -158,7 +158,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
 
   mcvine-resources-pkg:
     needs: check-permission
@@ -191,7 +191,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
       
   mcvine-instruments-pkg:
     needs: check-permission
@@ -224,7 +224,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
 
   mcvine-phonon-pkg:
     needs: check-permission
@@ -257,7 +257,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
 
   mcvine-ui-pkg:
     needs: check-permission
@@ -290,7 +290,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
 
   mcvine-workflow-pkg:
     needs: check-permission
@@ -323,7 +323,7 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg
 
   mcvine-pkg:
     needs: check-permission
@@ -357,4 +357,4 @@ jobs:
             CONDA_LABEL="rc"
           fi  
           echo $pkg pushing with label $CONDA_LABEL
-          # anaconda upload --label CONDA_LABEL --user $CONDA_USER
+          anaconda upload --label CONDA_LABEL --user $CONDA_USER $pkg


### PR DESCRIPTION
This is the second part of the CI for semi-automatic deployments on anaconda
- Only users of mcvine organization have access
- Only users of the deploy time can trigger a deploy
- The deploy workflows can only be triggered from the main branch
- The package name/path is checked for identifying the rc label, else it adds the main one

EWM: [McVine - Conda Recipes Github actions](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/10451)